### PR TITLE
Fix multiple camera-related crashes

### DIFF
--- a/astron/config/astrond.yml
+++ b/astron/config/astrond.yml
@@ -51,7 +51,7 @@ uberdogs:
 roles:
     - type: clientagent
       bind: 0.0.0.0:7198
-      version: "tto-dev"
+      version: "tt-cl-edition"
       client:
           relocate: true
           add_interest: enabled

--- a/config/dev.prc
+++ b/config/dev.prc
@@ -2,13 +2,13 @@
 # specific to developer instances of Toontown Online.
 
 # Window settings
-window-title Toontown Online [DEV]
+window-title Toontown: Crane League Edition
 
 # Notify settings
 console-output true
 
 # Server settings
-server-version tto-dev
+server-version tt-cl-edition
 
 # Developer settings
 want-dev false

--- a/otp/avatar/LocalAvatar.py
+++ b/otp/avatar/LocalAvatar.py
@@ -643,7 +643,13 @@ class LocalAvatar(DistributedAvatar.DistributedAvatar, DistributedSmoothNode.Dis
         self.updateSmartCameraCollisionLineSegment()
 
     def getIdealCameraPos(self):
-        return Point3(self.__idealCameraPos)
+        try:
+            return Point3(self.__idealCameraPos)
+        except AttributeError:
+            height = self.getClampedAvatarHeight()
+            point = Point3(height * (7 / 3.0), height * (-7 / 3.0), height)
+            self.setIdealCameraPos(point)
+            return Point3(self.__idealCameraPos)
 
     def setCameraPositionByIndex(self, index):
         self.notify.debug('switching to camera position %s' % index)
@@ -731,6 +737,7 @@ class LocalAvatar(DistributedAvatar.DistributedAvatar, DistributedSmoothNode.Dis
         return self.__geom
 
     def startUpdateSmartCamera(self, push = 1):
+        self.setCameraPositionByIndex(self.cameraIndex)
         self.orbitalCamera.start()
         return
         if self._smartCamEnabled:

--- a/otp/avatar/LocalAvatar.py
+++ b/otp/avatar/LocalAvatar.py
@@ -737,6 +737,7 @@ class LocalAvatar(DistributedAvatar.DistributedAvatar, DistributedSmoothNode.Dis
         return self.__geom
 
     def startUpdateSmartCamera(self, push = 1):
+        self.initCameraPositions()
         self.setCameraPositionByIndex(self.cameraIndex)
         self.orbitalCamera.start()
         return


### PR DESCRIPTION
The new camera implemented in the last contribution works well but has introduced multiple crashes throughout the game when leaving certain areas and finishing conversations with interactive NPCs. This pull request fixes that without changing the functionality of the camera. (it's just an AttributeError)

I also got bored and slightly changed the window title and version to look more customised to this source being the crane league edition.